### PR TITLE
Add specfile caching and fix tests

### DIFF
--- a/former/resource.py
+++ b/former/resource.py
@@ -90,8 +90,15 @@ class Property(object):
 
     def __new_resource(self, type):
         child_type = self.resource.split('.')[0] + '.' + type
-        if self.resource != child_type:
+
+        if self.resource != child_type and 'Properties' in TYPES.get(child_type, {}):
             return Resource(child_type).parameters()
+        elif self.resource != child_type:
+            return Property(
+                child_type,
+                TYPES[child_type].get(ITEM_TYPE, TYPES[child_type][PRIMITIVE_TYPE]),
+                TYPES[child_type]
+            ).type()
         else:
             return {'Recursive': self.resource, REQUIRED: self.required()}
 

--- a/former/specification.py
+++ b/former/specification.py
@@ -1,10 +1,17 @@
+import os
 import json
 
 import requests
 
+CACHE_PATH = '/tmp/former-spec.cached.json'
 
 def specification():
+    if os.path.exists(CACHE_PATH):
+        with open(CACHE_PATH) as f:
+            return json.load(f)
     response = requests.get(
         'https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json')
     response.raise_for_status()
+    with open(CACHE_PATH, 'w') as f:
+        f.write(response.text)
     return json.loads(response.text)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,10 +1,20 @@
+from __future__ import print_function
+import os
+
 import former.resource
+from former.specification import CACHE_PATH
 
 
 def test_former_for_every_resource():
-    keys = [key for key, value in former.resource.SPEC['ResourceTypes'].items()]
+    if os.path.exists(CACHE_PATH):
+        os.remove(CACHE_PATH)
+
+    keys = list(former.resource.SPEC['ResourceTypes'].keys())
     assert len(keys) > 0
-    print(keys)
-    for key in keys:
-        resource = former.resource.Resource(key)
-        resource.parameters()
+    for idx, key in enumerate(keys):
+        try:
+            resource = former.resource.Resource(key)
+            resource.parameters()
+        except:
+            print('Failed at type %s after %s successes' % (key, idx))
+            raise


### PR DESCRIPTION
Adds caching of specfile in `former-spec.cached.json`. `/tmp` is destroyed every reboot, and caching the specfile makes each `former` run 2x-7x faster by not calling out for the spec over the network.

While doing this patch, I found the tests were broken. The newly released AWS::SSM::PatchBaseline resource defines one parameter as an alias to string like this:

```
"AWS::SSM::PatchBaseline.PatchGroup": {
    "PrimitiveType": "String"
},
```

Which causes the `__new_resource` function to choke because it assumes
an alias is a complex type, so this adds an escape hatch for custom
types that have no `Properties`.
