### PR TITLE
Add handling for any network or parsing issues of the spec

### DIFF
--- a/former/cli.py
+++ b/former/cli.py
@@ -1,11 +1,11 @@
 import argparse
 import json
 import sys
+import traceback
 
 import yaml
 
 import former
-from former.resource import Resource
 
 
 def arguments():
@@ -14,12 +14,23 @@ def arguments():
     parser.add_argument('type')
     parser.add_argument('subtype', default='', nargs='?')
     parser.add_argument('--json', action='store_true')
+    parser.add_argument('--debug', '-d', action='store_true')
 
     return parser.parse_args()
 
 
 def main():
     args = arguments()
+
+    try:
+        from former.resource import Resource
+    except Exception as e:
+        print("Couldn't get spec for CloudFormation resources - usually this is a network issue.")
+        if args.debug:
+            traceback.print_exc()
+        else:
+            print("Use `former --debug` to get the full traceback")
+        sys.exit(1)
 
     type = former.resource.type_key(args.service, args.type, args.subtype)
     if type:

--- a/former/cli.py
+++ b/former/cli.py
@@ -29,6 +29,7 @@ def main():
         if args.debug:
             traceback.print_exc()
         else:
+            print("Exception: %s" % e)
             print("Use `former --debug` to get the full traceback")
         sys.exit(1)
 


### PR DESCRIPTION
On a bad network, I've had some issues with former crashing before parsing args at all. For a little nicer errors, added a `--debug` option to hide the traceback by default. 

New output:

```
$ former iam rolecd
HTTPSConnectionPool(host='d1uauaxba7bl26.cloudfront.net', port=443): Max retries exceeded with url: /latest/CloudFormationResourceSpecification.json (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f0e41579510>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Couldn't get spec for CloudFormation resources - usually this is a network issue.
Use `former --debug` to get the full traceback
$ former --debug iam rolecd
HTTPSConnectionPool(host='d1uauaxba7bl26.cloudfront.net', port=443): Max retries exceeded with url: /latest/CloudFormationResourceSpecification.json (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f9b90763510>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Couldn't get spec for CloudFormation resources - usually this is a network issue.
Traceback (most recent call last):
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/former/cli.py", line 26, in main
    from former.resource import Resource
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/former/resource.py", line 9, in <module>
    SPEC = specification.specification()
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/former/specification.py", line 11, in specification
    'https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json')
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/requests/api.py", line 72, in get
    return request('get', url, params=params, **kwargs)
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/requests/sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/requests/sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)
  File "/home/ryansb/.local/venvs/former/lib/python2.7/site-packages/requests/adapters.py", line 508, in send
    raise ConnectionError(e, request=request)
ConnectionError: HTTPSConnectionPool(host='d1uauaxba7bl26.cloudfront.net', port=443): Max retries exceeded with url: /latest/CloudFormationResourceSpecification.json (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f9b90763510>: Failed to establish a new connection: [Errno -2] Name or service not known',))
```