### PR TITLE
Output Resource not found error to stderr

### DIFF
--- a/former/cli.py
+++ b/former/cli.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import json
 import sys

--- a/former/cli.py
+++ b/former/cli.py
@@ -35,5 +35,5 @@ def main():
             output = yaml.safe_dump(data, allow_unicode=True, default_flow_style=False)
         print(output)
     else:
-        print('Resource not found for: {} {} {}'.format(args.service, args.type, args.subtype))
+        print('Resource not found for: {} {} {}'.format(args.service, args.type, args.subtype), file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
We use a bash function
```
function form { former $* | tail -n +2 | pbcopy; };
```
to automatically copy the data to the clipboard, but if we give a bad resource name we have no warning. This makes the Resource not found error visible.
