### PR TITLE
Adds support for opening the AWS docs to the target resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ want to get a quick overview for a subtype.
 ## Options
 
 * `--json` Print output in json instead of yaml
+* `--docs` Open the AWS docs to the resource specified

--- a/former/cli.py
+++ b/former/cli.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import sys
 import traceback
+import webbrowser
 
 import yaml
 
@@ -18,6 +19,7 @@ def arguments():
     parser.add_argument('subtype', default='', nargs='?')
     parser.add_argument('--json', action='store_true')
     parser.add_argument('--required', '-r', action='store_true')
+    parser.add_argument('--docs', '-o', action='store_true')
     parser.add_argument('--debug', '-d', action='store_true')
     return parser.parse_args()
 
@@ -44,6 +46,8 @@ def main():
         cf_resource['Properties'] = resource.parameters(args.required)
 
         data = {'Resources': {''.join(e for e in type if e.isalnum()): cf_resource}}
+        if args.docs:
+            webbrowser.open_new_tab(resource.documentation())
         if args.json:
             output = json.dumps(data, indent=2)
         else:

--- a/former/resource.py
+++ b/former/resource.py
@@ -39,6 +39,10 @@ class Resource(object):
                 properties[key] = prop_value
         return properties
 
+    def documentation(self):
+        root_resource = TYPES[self.root_type]
+        return root_resource['Documentation']
+
 
 class Property(object):
     def __init__(self, resource, property_type, definition, required_only):


### PR DESCRIPTION
Pass `--docs` or `-o` to open the docs as well as do any other functionality former offers.

It uses Python's built-in `webbrowser` module to open a new tab under the default browser to the target documentation url.

Example:

```
former s3 bucket --docs
```

Will display the s3 bucket cloudformation AND open a new tab to the CloudFormation documentation for the `AWS::S3::Bucket` resource.

I didn't bump the version, I'll let the maintainer do that to whatever version they're comfortable with.