### PR TITLE
Feature/windows support

### DIFF
--- a/former/specification.py
+++ b/former/specification.py
@@ -9,6 +9,7 @@ if platform.system() == 'Windows':
     CACHE_PATH = pathlib.WindowsPath(os.getenv('TEMP', '~') + '/former-spec.cached.json').expanduser()
 else:
     CACHE_PATH = pathlib.Path('/tmp/former-spec.cached.json')
+CACHE_PATH = str(CACHE_PATH)
 
 
 def specification():

--- a/former/specification.py
+++ b/former/specification.py
@@ -6,7 +6,7 @@ import pathlib
 import requests
 
 if platform.system() == 'Windows':
-    CACHE_PATH = pathlib.WindowsPath(os.getenv('TEMP') + '/former-spec.cached.json')
+    CACHE_PATH = pathlib.WindowsPath(os.getenv('TEMP', '~') + '/former-spec.cached.json').expanduser()
 else:
     CACHE_PATH = pathlib.Path('/tmp/former-spec.cached.json')
 

--- a/former/specification.py
+++ b/former/specification.py
@@ -1,13 +1,14 @@
 import os
 import json
 import platform
+import pathlib
 
 import requests
 
 if platform.system() == 'Windows':
-    CACHE_PATH = os.getenv('TEMP') + '\former-spec.cached.json'
+    CACHE_PATH = pathlib.WindowsPath(os.getenv('TEMP') + '/former-spec.cached.json')
 else:
-    CACHE_PATH = '/tmp/former-spec.cached.json'
+    CACHE_PATH = pathlib.Path('/tmp/former-spec.cached.json')
 
 
 def specification():

--- a/former/specification.py
+++ b/former/specification.py
@@ -1,9 +1,13 @@
 import os
 import json
+import platform
 
 import requests
 
-CACHE_PATH = '/tmp/former-spec.cached.json'
+if platform.system() == 'Windows':
+    CACHE_PATH = os.getenv('TEMP') + '\former-spec.cached.json'
+else:
+    CACHE_PATH = '/tmp/former-spec.cached.json'
 
 
 def specification():

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     keywords='cloudformation, aws, cloud',
     packages=['former'],
-    install_requires=['requests', 'pyyaml'],
+    install_requires=['requests', 'pyyaml', 'pathlib'],
     entry_points={
         'console_scripts': [
             'former=former.cli:main',


### PR DESCRIPTION
Fixes windows support from bug with cache path
Uses `platform` to detect if the user is running on Windows
Uses `pathlib` and `TEMP` environment variable to construct windows path, defaulting to the user's home directory if for some reason `TEMP` is not set